### PR TITLE
Fix viewport meta tag syntax in root.tsx

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -43,9 +43,7 @@ export const links: LinksFunction = () => {
 };
 
 export const meta: V2_MetaFunction = () => [
-  { charset: "utf-8" },
   { title: "Remix Ghost Stack - Remix App with Ghost CMS in Headless Mode" },
-  { name: "viewport", content: "width=device-width,initial-scale=1" },
 ];
 
 export async function loader({ request }: LoaderArgs) {
@@ -61,6 +59,8 @@ function App() {
   return (
     <html lang="en" className={clsx("h-full", theme)}>
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
         <NonFlashOfWrongThemeEls ssrTheme={Boolean(data.theme)} />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,13 +17,13 @@ import {
   useLoaderData,
   type ShouldRevalidateFunction,
 } from "@remix-run/react";
-import clsx from "clsx";
-import { ClientOnly } from "remix-utils";
 import {
   NonFlashOfWrongThemeEls,
   ThemeProvider,
   useTheme,
 } from "~/ui/utils/theme-provider";
+import clsx from "clsx";
+import { ClientOnly } from "remix-utils";
 
 import { Toaster } from "~/ui/components/toaster";
 
@@ -45,7 +45,7 @@ export const links: LinksFunction = () => {
 export const meta: V2_MetaFunction = () => [
   { charset: "utf-8" },
   { title: "Remix Ghost Stack - Remix App with Ghost CMS in Headless Mode" },
-  { viewport: "width=device-width,initial-scale=1" },
+  { name: "viewport", content: "width=device-width,initial-scale=1" },
 ];
 
 export async function loader({ request }: LoaderArgs) {

--- a/app/routes/_blog.$slug.tsx
+++ b/app/routes/_blog.$slug.tsx
@@ -5,9 +5,9 @@ import {
   useLoaderData,
   useRouteError,
 } from "@remix-run/react";
+import type { loader as rootBlogLoader } from "~/routes/_blog";
 import { Star } from "lucide-react";
 import type { Article } from "schema-dts";
-import type { loader as rootBlogLoader } from "~/routes/_blog";
 
 import { Markdown } from "~/services/markdoc/components/markdown";
 import { LinkButton } from "~/ui/components";
@@ -80,14 +80,12 @@ export const meta: V2_MetaFunction<
   };
 
   return [
-    { charset: "utf-8" },
     { title: post.meta_title || post.title },
     {
       tagName: "link",
       rel: "canonical",
       href: post.url || "",
     },
-    { name: "viewport", content: "width=device-width,initial-scale=1" },
     {
       name: "description",
       content: post.meta_description || post.excerpt,

--- a/app/routes/_blog.tag.$slug.tsx
+++ b/app/routes/_blog.tag.$slug.tsx
@@ -4,10 +4,10 @@ import {
   useLoaderData,
   useRouteError,
 } from "@remix-run/react";
+import type { loader as rootBlogLoader } from "~/routes/_blog";
 import { ArrowLeft } from "lucide-react";
 import type { CreativeWorkSeries } from "schema-dts";
 import invariant from "tiny-invariant";
-import type { loader as rootBlogLoader } from "~/routes/_blog";
 
 import { LinkButton } from "~/ui/components";
 import { PostsList } from "~/ui/components/posts/posts-list";
@@ -49,14 +49,12 @@ export const meta: V2_MetaFunction<
   };
 
   return [
-    { charset: "utf-8" },
     { title: tag.meta_title || tag.og_title || tag.name },
     {
       tagName: "link",
       rel: "canonical",
       href: tag.url || "",
     },
-    { name: "viewport", content: "width=device-width,initial-scale=1" },
     {
       name: "description",
       content: tag.meta_description || tag.og_description || tag.description,

--- a/app/routes/_blog.tsx
+++ b/app/routes/_blog.tsx
@@ -47,9 +47,7 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data }) => {
     description: settings.description,
   };
   return [
-    { charset: "utf-8" },
     { title: settings.title },
-    { name: "viewport", content: "width=device-width,initial-scale=1" },
     {
       name: "description",
       content: settings.meta_description || settings.description,


### PR DESCRIPTION
~Use the correct `V2_MetaFunction` syntax to add the viewport in `root.tsx`~

Prefer traditional syntax for global meta tags:
ie. https://remix.run/docs/en/main/route/meta#global-meta